### PR TITLE
Update marked-images.js

### DIFF
--- a/marked-images.js
+++ b/marked-images.js
@@ -47,7 +47,7 @@ module.exports = function markedImage(renderer) {
     var m;
     a.forEach(function(w) {
       if (m = w.match(/^(\d+)x(\d+)$/)) return (out += ' width="' + m[1] + '" height="' + m[2] + '"');
-      if (m = w.match(/^(\w+)=(\w+)$/)) return (out += ' ' + m[1] + '="' + m[2] + '"');
+      if (m = w.match(/^(\S+)=(\S+)$/)) return (out += ' ' + m[1] + '="' + m[2] + '"');
       if (w) return b.push(w);
     })
     title = b.join(' ');


### PR DESCRIPTION
Hello,
Using match with word characters only (\w) makes it impossible to write class names with dashes, eg. "class=large-image". When changed to match non-whitespace characters (\S) it becomes possible.

Regards,
Kamoris
